### PR TITLE
add compatability for devices

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -154,7 +154,7 @@
   <project path="external/sonivox" name="platform/external/sonivox" />
   <project path="external/speex" name="platform/external/speex" />
   <project path="external/sqlite" name="platform/external/sqlite" />
-  <project path="external/srec" name="platform/external/srec" />
+  <project path="external/srec" name="CyanogenMod/android_external_srec" remote="github" revision="jellybean" />
   <project path="external/srtp" name="platform/external/srtp" />
   <project path="external/stlport" name="platform/external/stlport" />
   <project path="external/strace" name="platform/external/strace" />


### PR DESCRIPTION
using the cm10 srec gets rid of build errors that can occur. It will still build the official devices, and add support for older devices

build error caused by aosp srec:
target thumb C++: libSR_AudioIn <= external/srec/audio/AudioIn/UNIX/src/audioinwrapper.cpp
external/srec/audio/AudioIn/UNIX/src/audioinwrapper.cpp: In function 'int AudioSetVolume(int, int)':
external/srec/audio/AudioIn/UNIX/src/audioinwrapper.cpp:155:61: error: invalid conversion from 'int' to 'audio_stream_type_t' [-fpermissive]
frameworks/av/include/media/AudioSystem.h:58:21: error:   initializing argument 1 of 'static android::status_t android::AudioSystem::setStreamVolume(audio_stream_type_t, float, audio_io_handle_t)' [-fpermissive]
external/srec/audio/AudioIn/UNIX/src/audioinwrapper.cpp: In function 'int AudioGetVolume(int)':
external/srec/audio/AudioIn/UNIX/src/audioinwrapper.cpp:165:50: error: invalid conversion from 'int' to 'audio_stream_type_t' [-fpermissive]
frameworks/av/include/media/AudioSystem.h:60:21: error:   initializing argument 1 of 'static android::status_t android::AudioSystem::getStreamVolume(audio_stream_type_t, float_, audio_io_handle_t)' [-fpermissive]
make: *_\* [out/target/product/p350/obj/SHARED_LIBRARIES/libSR_AudioIn_intermediates/audioinwrapper.o] Error 1
make: **\* Waiting for unfinished jobs....
true

changing to cm10 srec fixes
